### PR TITLE
Simplify the logic of `End when dst is `Manual.

### DIFF
--- a/src/jsonm.mli
+++ b/src/jsonm.mli
@@ -165,16 +165,19 @@ val encode : encoder -> [< `Await | `End | `Lexeme of lexeme ] ->
   [`Ok | `Partial]
 (** [encode e v] is:
     {ul
-    {- [`Partial] iff [e] has a [`Manual] destination and needs more
-       output storage. The client must use {!Manual.dst} to provide
-       a new buffer and then call {!encode} with [`Await] until [`Ok]
-       is returned.}
+    {- [`Partial] iff [e] has a [`Manual] destination and either
+       needs more output storage or has leftover in the buffer
+       when encountering [`End]. In the former case, the client must
+       use {!Manual.dst} to provide a new buffer and then call
+       {!encode} with [`Await] until [`Ok] is returned.}
     {- [`Ok] when the encoder is ready to encode a new [`Lexeme]
        or [`End].}}
-    For [`Manual] destinations, encoding [`End] always returns [`Partial],
-    the client should as usual use {!Manual.dst} and continue with [`Await]
-    until [`Ok] is returned at which point {!Manual.dst_rem} [e] is guaranteed
-    to be the size of the last provided buffer (i.e. nothing was written).
+    For [`Manual] destinations, encoding [`End] returns [`Partial]
+    when there is leftover in the output buffer and [`Ok] otherwise.
+    In the former case, the client should as usual use {!Manual.dst}
+    and continue with [`Await] until [`Ok] is returned at which point
+    {!Manual.dst_rem} [e] is guaranteed to be the size of the last
+    provided buffer (i.e. nothing was written).
 
     {b Raises.} [Invalid_argument] if a non {{!datamodel}well-formed}
     sequence of lexemes is encoded or if [`Lexeme] or [`End] is


### PR DESCRIPTION
This is a suggestion to simplify (from the client's point of view) the handling of ``` `End```. Currently, when encoding ``` `End```, (it seems) the encoder could output ``` `Partial``` even if there is nothing left in the output buffer. This complicates the client code because many streaming libraries treat a zero-sized input buffer as a signal of the end of the stream, and thus the client has to check whether the buffer is empty and send an additional ``` `Await``` when necessary. This PR internalizes this checking.

The new code would establish a simple invariant that there is always some content in the output buffer whenever ``` `Partial``` is emitted (unless the buffer itself is `Bytes.empty`). In other words, if we ignore ill-formed JSON for the moment, it will always output ``` `Ok``` when there's nothing left.

This might be a breaking change for the clients which choose to ignore the first ``` `Partial``` after encoding ``` `End```. However, I claim that the client was already semantically wrong and should be fixed.

In case you think the old behavior should be maintained, the "iff" statement about ``` `Partial``` in the documentation needs to take into account the ``` `End``` case---``` `Partial``` can happen even if the encoder is not asking for more storage.

Thank you for your consideration. If you choose to adopt the change, please feel free to wordsmith the documentation.