### PR TITLE
[RFC] Jsonm.Value: encoding and decoding complete values

### DIFF
--- a/src/jsonm.ml
+++ b/src/jsonm.ml
@@ -631,30 +631,53 @@ module Uncut = struct
 end
 
 module Value = struct
-  type 'loc t = 'loc value * 'loc
-  and 'loc value = [
-  | `Null
-  | `Bool of bool
-  | `Float of float
-  | `String of string
-  | `A of 'loc t list
-  | `O of ((string * 'loc) * 'loc t) list
-  ]
+  module With_loc = struct
+    type t = value * range
+    and value = [
+    | `Null
+    | `Bool of bool
+    | `Float of float
+    | `String of string
+    | `A of t list
+    | `O of ((string * range) * t) list
+    ]
+  end
 
-  type 'loc decode_result = [
-  | `Value of 'loc t
+  module Without_loc = struct
+    type t = value
+    and value = [
+    | `Null
+    | `Bool of bool
+    | `Float of float
+    | `String of string
+    | `A of t list
+    | `O of (string * t) list
+    ]
+  end
+
+  let rec erase_locs ((v, _loc) : With_loc.t) : Without_loc.t =
+    match v with
+    | (`Null | `Bool _ | `Float _ | `String _) as v ->
+        v
+    | `A vs ->
+        `A (List.rev (List.rev_map erase_locs vs))
+    | `O ms ->
+        `O (List.rev (List.map (fun ((n, _loc), v) -> (n, erase_locs v)) ms))
+
+  type decode_result = [
+  | `Value of With_loc.t
      (** Decoding a full value succeeded. *)
   | `Decoding_error of error
     (** Decoding failed with an error. *)
   | `Unexpected of [ `Lexeme of lexeme | `End ]
     (** Unexpected (gramatically invalid) lexeme or end-of-input *)
-  | `Await of unit -> 'loc decode_result
+  | `Await of unit -> decode_result
     (** The decoder uses a [`Manual]  source and awaits for more input.
         The client must use {!Manual.src} to provide it and call the returned
         thunk to keep decoding the value. *)
   ]
 
-  let decode d : range decode_result =
+  let decode d : decode_result =
     let rec dec d f pos st k = match decode d with
     | `Lexeme l -> f d pos st l k
     | `Error err -> `Decoding_error err
@@ -698,7 +721,7 @@ module Value = struct
     | `Partial -> `Partial (fun () -> feed e `Await f v k)
     in
     let enc e l f v k = feed e (`Lexeme l) f v k in
-    let rec value e (v, _loc) k = match v with
+    let rec value e v k = match v with
     | `A vs -> enc e `As arr vs k
     | `O ms -> enc e `Os obj ms k
     | (`Null | `Bool _ | `Float _ | `String _) as l -> enc e l continue () k
@@ -706,7 +729,7 @@ module Value = struct
     | v :: vs' -> value e v (fun e -> arr e vs' k)
     | [] -> enc e `Ae continue () k
     and obj e ms k = match ms with
-    | ((n, _loc), v) :: ms -> enc e (`Name n) value v (fun e -> obj e ms k)
+    | (n, v) :: ms -> enc e (`Name n) value v (fun e -> obj e ms k)
     | [] -> enc e `Oe continue () k
     and continue e () k = k e
     in

--- a/src/jsonm.mli
+++ b/src/jsonm.mli
@@ -449,45 +449,34 @@ let memsel ?encoding names
   and decode them.
 *)
 module Value : sig
-  module With_loc : sig
-    type t = value * range
-    and value = [
-    | `Null
-    | `Bool of bool
-    | `Float of float
-    | `String of string
-    | `A of t list
-    | `O of ((string * range) * t) list
-    ]
-  end
+  type 'loc t = 'loc value * 'loc
+  and 'loc value = [
+  | `Null
+  | `Bool of bool
+  | `Float of float
+  | `String of string
+  | `A of 'loc t list
+  | `O of ((string * 'loc) * 'loc t) list
+  ]
+  (** The type of JSON trees is parametrized over the type 'loc
+      representing source locations. In particular you can use
+      [unit value] to represent JSON values without position information,
+      and our decoders return [range value], pairing nodes in the tree
+      with the corresponding character range in the input source. *)
 
-  type decode_result = [
-  | `Value of With_loc.t
+  type 'loc decode_result = [
+  | `Value of 'loc t
      (** Decoding a full value succeeded. *)
   | `Decoding_error of error
     (** Decoding failed with an error. *)
   | `Unexpected of [ `Lexeme of lexeme | `End ]
     (** Unexpected (gramatically invalid) lexeme or end-of-input *)
-  | `Await of unit -> decode_result
+  | `Await of unit -> 'loc decode_result
     (** The decoder uses a [`Manual]  source and awaits for more input.
         The client must use {!Manual.src} to provide it and call the returned
         thunk to keep decoding the value. *)
   ]
-  val decode : decoder -> decode_result
-
-  module Without_loc : sig
-    type t = value
-    and value = [
-    | `Null
-    | `Bool of bool
-    | `Float of float
-    | `String of string
-    | `A of t list
-    | `O of (string * t) list
-    ]
-  end
-
-  val erase_locs : With_loc.t -> Without_loc.t
+  val decode : decoder -> range decode_result
 
   type encode_result = [
   | `Ok
@@ -497,7 +486,7 @@ module Value : sig
         The client must use {!Manual.dst} to provide a new buffer, and then call
         the provided thunk to keep encoding the value. *)
   ]
-  val encode : encoder -> Without_loc.t -> encode_result
+  val encode : encoder -> 'loc t -> encode_result
 end
 
 (*---------------------------------------------------------------------------

--- a/src/jsonm.mli
+++ b/src/jsonm.mli
@@ -449,34 +449,45 @@ let memsel ?encoding names
   and decode them.
 *)
 module Value : sig
-  type 'loc t = 'loc value * 'loc
-  and 'loc value = [
-  | `Null
-  | `Bool of bool
-  | `Float of float
-  | `String of string
-  | `A of 'loc t list
-  | `O of ((string * 'loc) * 'loc t) list
-  ]
-  (** The type of JSON trees is parametrized over the type 'loc
-      representing source locations. In particular you can use
-      [unit value] to represent JSON values without position information,
-      and our decoders return [range value], pairing nodes in the tree
-      with the corresponding character range in the input source. *)
+  module With_loc : sig
+    type t = value * range
+    and value = [
+    | `Null
+    | `Bool of bool
+    | `Float of float
+    | `String of string
+    | `A of t list
+    | `O of ((string * range) * t) list
+    ]
+  end
 
-  type 'loc decode_result = [
-  | `Value of 'loc t
+  type decode_result = [
+  | `Value of With_loc.t
      (** Decoding a full value succeeded. *)
   | `Decoding_error of error
     (** Decoding failed with an error. *)
   | `Unexpected of [ `Lexeme of lexeme | `End ]
     (** Unexpected (gramatically invalid) lexeme or end-of-input *)
-  | `Await of unit -> 'loc decode_result
+  | `Await of unit -> decode_result
     (** The decoder uses a [`Manual]  source and awaits for more input.
         The client must use {!Manual.src} to provide it and call the returned
         thunk to keep decoding the value. *)
   ]
-  val decode : decoder -> range decode_result
+  val decode : decoder -> decode_result
+
+  module Without_loc : sig
+    type t = value
+    and value = [
+    | `Null
+    | `Bool of bool
+    | `Float of float
+    | `String of string
+    | `A of t list
+    | `O of (string * t) list
+    ]
+  end
+
+  val erase_locs : With_loc.t -> Without_loc.t
 
   type encode_result = [
   | `Ok
@@ -486,7 +497,7 @@ module Value : sig
         The client must use {!Manual.dst} to provide a new buffer, and then call
         the provided thunk to keep encoding the value. *)
   ]
-  val encode : encoder -> 'loc t -> encode_result
+  val encode : encoder -> Without_loc.t -> encode_result
 end
 
 (*---------------------------------------------------------------------------

--- a/src/jsonm.mli
+++ b/src/jsonm.mli
@@ -451,11 +451,11 @@ let memsel ?encoding names
 module Value : sig
   type 'loc t = [
   | `Null of 'loc
-  | `Bool of 'loc * bool
-  | `Float of 'loc * float
-  | `String of 'loc * string
-  | `A of 'loc * 'loc t list
-  | `O of 'loc * (('loc * string) * 'loc t) list
+  | `Bool of bool * 'loc
+  | `Float of float * 'loc
+  | `String of string * 'loc
+  | `A of 'loc t list * 'loc
+  | `O of ((string * 'loc) * 'loc t) list * 'loc
   ]
   (** The type of JSON trees is parametrized over the type 'loc
       representing source locations. In particular you can use

--- a/src/jsonm.mli
+++ b/src/jsonm.mli
@@ -449,19 +449,18 @@ let memsel ?encoding names
   and decode them.
 *)
 module Value : sig
-  type 'loc t = 'loc value * 'loc
-  and 'loc value = [
-  | `Null
-  | `Bool of bool
-  | `Float of float
-  | `String of string
-  | `A of 'loc t list
-  | `O of ((string * 'loc) * 'loc t) list
+  type 'loc t = [
+  | `Null of 'loc
+  | `Bool of 'loc * bool
+  | `Float of 'loc * float
+  | `String of 'loc * string
+  | `A of 'loc * 'loc t list
+  | `O of 'loc * (('loc * string) * 'loc t) list
   ]
   (** The type of JSON trees is parametrized over the type 'loc
       representing source locations. In particular you can use
-      [unit value] to represent JSON values without position information,
-      and our decoders return [range value], pairing nodes in the tree
+      [unit t] to represent JSON values without position information,
+      and our decoders return [range t], pairing nodes in the tree
       with the corresponding character range in the input source. *)
 
   type 'loc decode_result = [

--- a/test/test.ml
+++ b/test/test.ml
@@ -319,10 +319,9 @@ let trip () =
     let e = Jsonm.encoder (`Buffer b) in
     let v =
       match Jsonm.Value.decode d with
-      | `Value v -> v
+      | `Value v ->v
       | `Decoding_error _ | `Unexpected _ | `Await _ -> assert false
     in
-    let v = Jsonm.Value.erase_locs v in
     let () =
       match Jsonm.Value.encode e v with
       | `Ok -> ()

--- a/test/test.ml
+++ b/test/test.ml
@@ -319,9 +319,10 @@ let trip () =
     let e = Jsonm.encoder (`Buffer b) in
     let v =
       match Jsonm.Value.decode d with
-      | `Value v ->v
+      | `Value v -> v
       | `Decoding_error _ | `Unexpected _ | `Await _ -> assert false
     in
+    let v = Jsonm.Value.erase_locs v in
     let () =
       match Jsonm.Value.encode e v with
       | `Ok -> ()

--- a/test/test.ml
+++ b/test/test.ml
@@ -6,7 +6,10 @@
 let str = Format.sprintf
 let log f = Format.printf (f ^^ "@?")
 let fail fmt =
-  let fail _ = failwith (Format.flush_str_formatter ()) in
+  let fail _ =
+    let msg = Format.flush_str_formatter () in
+    Printf.eprintf "Failure: %s%!" msg;
+    failwith msg in
   Format.kfprintf fail Format.str_formatter fmt
 
 let encoder_invalid () =

--- a/test/test.ml
+++ b/test/test.ml
@@ -295,7 +295,7 @@ let decoder_eoi () =
 
 let trip () =
   log "Codec round-trips.\n";
-  let trip s =
+  let trip_streaming s =
     let b = Buffer.create (String.length s) in
     let d = Jsonm.decoder (`String s) in
     let e = Jsonm.encoder (`Buffer b) in
@@ -308,7 +308,29 @@ let trip () =
     loop d e;
     let trips = Buffer.contents b in
     if trips <> s then
-    fail "fnd: %s@\nexp: %s@\n" trips s
+    fail "streaming@\nfnd: %s@\nexp: %s@\n" trips s
+  in
+  let trip_value s =
+    let b = Buffer.create (String.length s) in
+    let d = Jsonm.decoder (`String s) in
+    let e = Jsonm.encoder (`Buffer b) in
+    let v =
+      match Jsonm.Value.decode d with
+      | `Value v ->v
+      | `Decoding_error _ | `Unexpected _ | `Await _ -> assert false
+    in
+    let () =
+      match Jsonm.Value.encode e v with
+      | `Ok -> ()
+      | `Partial _ -> assert false
+    in
+    let trips = Buffer.contents b in
+    if trips <> s then
+    fail "value@\nfnd: %s@\nexp: %s@\n" trips s
+  in
+  let trip s =
+    trip_streaming s;
+    trip_value s;
   in
   trip "null";
   trip "true";


### PR DESCRIPTION
This is a Request For Comment rather than a complete pull request, although the implementation is sensible and I welcome review comments.

Jsonm is a streaming library that provides a linear view of a JSON document. The point of view of the current documentation is that encoding and decoding tree-representations of JSON values (which a large share of JSON users actually need/want) is left as an easy exercise for users, and given as [an example](https://erratique.ch/software/jsonm/doc/Jsonm/index.html#tree) in the documentation. However, this approach has the following downsides:

1. The example in the documentation has bad error-handling, and users who naively reuse it get bad error-handling in their code. It requires some work to understand how to handle errors properly, and this work was duplicated many times.
2. Support libraries pop up to implement JSON tree representations on top of Jsonm, Ezjsonm being the most popular (it has more dependents than Jsonm itself on OPAM), json_of_jsonm appears to be an unmaintained experiment. Guess what: their error-handling is rather bad.

I did the work to convert an Ezjsonm user to Jsonm to get proper error locations in https://github.com/rgrinberg/ocaml-mustache/pull/63 , and I would like to avoid this work to other users. I am planning to contribute better error-handling to Ezjsonm, but I think that the best approach for everyone would be to have proper tree-representation support *as a convenience* in Jsonm, well-integrated with its API.

The current PR is a proposal for such an integration of Json "values" (tree representations) in Jsonm. It uses the value type coming from the declaration example, but provides proper error handling and supports the `Manual` encoder/decoders. I believe that the API proposal and the implementation are solid, and there is some testing (no testing of `Manual` encoders/decoders, though), but I suspect that @dbuenzli would want to see improvements to the documentation. Given that there is a good chance that @dbuenzli would not be interested in the feature at all, I am submitting the PR in this current state (documentation not completely finished) to get a conversation started.